### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,5 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 packages:
   - packages/*
 
+allowBuilds:
+  "@parcel/watcher": false
+  esbuild: false
+  unrs-resolver: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`