### PR TITLE
chore: exempt first-party packages from pnpm minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,10 @@ allowBuilds:
   "@parcel/watcher": false
   esbuild: false
   unrs-resolver: false
+
+minimumReleaseAgeExclude:
+  - nuxt
+  - nuxt-nightly
+  - '@nuxt/*'
+  - vue
+  - '@vue/*'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

because this repo extends [nuxt's renovate preset](https://github.com/nuxt/renovate-config-nuxt/blob/main/default.json#L22-L28), which itself excludes these first-party packages from the release age check, it's necessary to update `pnpm-workspace.yaml` to mirror the same list to avoid artifact update failures.